### PR TITLE
Fix last commit series

### DIFF
--- a/source/SymEngine.cpp
+++ b/source/SymEngine.cpp
@@ -1241,8 +1241,8 @@ void CSymEngine::GetOsInfo(COsInfo& rOsInfo)
 				case VER_NT_WORKSTATION:
 					rOsInfo.m_pszWinVersion = szWindowsVista;
 					break;
-					//case VER_NT_DOMAIN_CONTROLLER:
-					//case VER_NT_SERVER:
+				//case VER_NT_DOMAIN_CONTROLLER:
+				//case VER_NT_SERVER:
 				default:
 					rOsInfo.m_pszWinVersion = szWindowsServer2008;
 					break;
@@ -1254,8 +1254,8 @@ void CSymEngine::GetOsInfo(COsInfo& rOsInfo)
 				case VER_NT_WORKSTATION:
 					rOsInfo.m_pszWinVersion = szWindows7;
 					break;
-					//case VER_NT_DOMAIN_CONTROLLER:
-					//case VER_NT_SERVER:
+				//case VER_NT_DOMAIN_CONTROLLER:
+				//case VER_NT_SERVER:
 				default:
 					rOsInfo.m_pszWinVersion = szWindowsServer2008R2;
 					break;


### PR DESCRIPTION
Somehow I committed wrong patch (?!). Here's what has been fixed:
- dwAvailPhys/other dw\* fields from MEMORYSTATUSEX should be ullAvailPhys/ull*
- Since we need to format 64-bit (unsigned long long) numbers, _ui64tot_s should be used instead of _ultot_s
- Use tabs for identation, like original code
