### PR TITLE
Add a flag to hide the "More..." button in SimpleDlg

### DIFF
--- a/source/Client/BugTrap.h
+++ b/source/Client/BugTrap.h
@@ -106,6 +106,12 @@ typedef enum BUGTRAP_FLAGS_tag
 	 */
 	BTF_ATTACHREPORT   = 0x004,
 	/**
+	 * @brief By default BugTrap show a "More..." button to open
+	 * the advanced ui in the simple dialog. Enable this flag
+	 * hide the button.
+	 */
+	BTF_HIDEMOREBUTTON = 0x006,
+	/**
 	 * @brief Set this flag to add list of all processes and loaded
 	 * modules to the report. Disable this option to speedup report
 	 * generation.

--- a/source/Client/SimpleDlg.cpp
+++ b/source/Client/SimpleDlg.cpp
@@ -119,6 +119,11 @@ static void InitControls(HWND hwnd)
 			ShowWindow(hwndMailTo, SW_HIDE);
 	}
 
+	if (g_dwFlags & BTF_HIDEMOREBUTTON)
+	{
+		ShowWindow(hwndMore, FALSE);
+	}
+
 	HWND hwndFocus = IsWindowEnabled(hwndSubmitBug) ? hwndSubmitBug : hwndClose;
 	SetFocus(hwndFocus);
 	SendMessage(hwnd, DM_SETDEFID, GetDlgCtrlID(hwndFocus), 0l);


### PR DESCRIPTION
I adding a flag `BTF_HIDEMOREBUTTON` (don't hesitate if you have a better name). For hiding the "More..." button in the simple dialog.

With BTF_HIDEMOREBUTTON (without button): 
![0](https://user-images.githubusercontent.com/1573282/226131200-343f17c3-10f9-47c0-bbf5-33d772fc8b1e.png)


Without BTF_HIDEMOREBUTTON (with button):
![1](https://user-images.githubusercontent.com/1573282/226131210-966a517d-e159-4e0e-ac52-88cb3c2aae3e.png)
