### PR TITLE
fix: Change enum BTF_HIDEMOREBUTTON from 0x006 to 0x400, otherwise it will conflict with BTF_ATTACHREPORT.

### DIFF
--- a/source/Client/BugTrap.h
+++ b/source/Client/BugTrap.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This is a part of the BugTrap package.
  * Copyright (c) 2005-2009 IntelleSoft.
  * All rights reserved.
@@ -160,7 +160,7 @@ typedef enum BUGTRAP_FLAGS_tag
       * the advanced ui in the simple dialog. Enable this flag
       * hide the button.
       */
-     BTF_HIDEMOREBUTTON = 0x400
+     BTF_HIDEMOREBUTTON = 0x400,
 }
 BUGTRAP_FLAGS;
 

--- a/source/Client/BugTrap.h
+++ b/source/Client/BugTrap.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This is a part of the BugTrap package.
  * Copyright (c) 2005-2009 IntelleSoft.
  * All rights reserved.
@@ -106,12 +106,6 @@ typedef enum BUGTRAP_FLAGS_tag
 	 */
 	BTF_ATTACHREPORT   = 0x004,
 	/**
-	 * @brief By default BugTrap show a "More..." button to open
-	 * the advanced ui in the simple dialog. Enable this flag
-	 * hide the button.
-	 */
-	BTF_HIDEMOREBUTTON = 0x006,
-	/**
 	 * @brief Set this flag to add list of all processes and loaded
 	 * modules to the report. Disable this option to speedup report
 	 * generation.
@@ -160,7 +154,13 @@ typedef enum BUGTRAP_FLAGS_tag
 	  * @brief Automatically restart the application after the crash has been
 	  * handled.
 	  */
-	 BTF_RESTARTAPP    = 0x200
+	 BTF_RESTARTAPP    = 0x200,
+     /**
+      * @brief By default BugTrap show a "More..." button to open
+      * the advanced ui in the simple dialog. Enable this flag
+      * hide the button.
+      */
+     BTF_HIDEMOREBUTTON = 0x400
 }
 BUGTRAP_FLAGS;
 

--- a/source/Examples/BugTrapTest/BugTrapTest.cpp
+++ b/source/Examples/BugTrapTest/BugTrapTest.cpp
@@ -1,4 +1,4 @@
-// BugTrapTest.cpp : Defines the class behaviors for the application.
+﻿// BugTrapTest.cpp : Defines the class behaviors for the application.
 //
 
 #include "stdafx.h"
@@ -32,7 +32,7 @@ CBugTrapTestApp::CBugTrapTestApp()
 	// Setup exception handler
 	BT_SetAppName(_T("BugTrap Test"));
 	BT_SetSupportEMail(_T("your@email.com"));
-	BT_SetFlags(BTF_DETAILEDMODE | BTF_EDITMAIL | BTF_ATTACHREPORT| BTF_SCREENCAPTURE);
+	BT_SetFlags(BTF_DETAILEDMODE | BTF_EDITMAIL | BTF_ATTACHREPORT | BTF_SCREENCAPTURE);
 	BT_SetSupportURL(_T("http://www.intellesoft.net"));
 
 	// = BugTrapServer ===========================================

--- a/source/Examples/BugTrapTest/BugTrapTest.cpp
+++ b/source/Examples/BugTrapTest/BugTrapTest.cpp
@@ -1,4 +1,4 @@
-﻿// BugTrapTest.cpp : Defines the class behaviors for the application.
+// BugTrapTest.cpp : Defines the class behaviors for the application.
 //
 
 #include "stdafx.h"


### PR DESCRIPTION
Fixed enum error, otherwise you couldn't see the "More.." button when you use BTF_ATTACHREPORT flag.